### PR TITLE
Update webpack config for webpack middleware in express

### DIFF
--- a/client/build/dev.server.config.js
+++ b/client/build/dev.server.config.js
@@ -1,0 +1,22 @@
+const webpack = require('webpack');
+const path = require('path');
+const merge = require('webpack-merge');
+const baseWebpackConfig = require('./webpack.base.conf');
+
+const devWebpackConfig = merge(baseWebpackConfig, {
+  entry: [
+    'webpack-hot-middleware/client?path=/__webpack_hmr&timeout=20000',
+    './src/main.js',
+  ],
+  output: {
+    path: path.join(__dirname, 'www'),
+    filename: 'bundle.js',
+    publicPath: '/dist/',
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoEmitOnErrorsPlugin(),
+  ],
+});
+
+module.exports = devWebpackConfig;

--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "author": "jybaek <oops.jybaek@gmail.com>",
   "private": true,
   "scripts": {
+    "start:dev": "cross-env NODE_ENV=development node ./bin/server",
     "dev": "webpack-dev-server --inline --progress --config build/webpack.dev.conf.js",
     "start": "npm run dev",
     "unit": "jest --config test/unit/jest.conf.js --coverage",
@@ -37,6 +38,7 @@
     "chalk": "^2.0.1",
     "chromedriver": "^2.27.2",
     "copy-webpack-plugin": "^4.0.1",
+    "cross-env": "^5.1.4",
     "cross-spawn": "^5.0.1",
     "css-loader": "^0.28.0",
     "extract-text-webpack-plugin": "^3.0.0",


### PR DESCRIPTION
- Add cross-env modules for seperating server's env flag.
- Add node's script for development server.
- Add webpack config file to use webpack-middleware in express server.